### PR TITLE
create file when :force is true in File::create_file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/

--- a/lib/tty/file/create_file.rb
+++ b/lib/tty/file/create_file.rb
@@ -64,6 +64,7 @@ module TTY
             log_status(:identical, relative_path, options.fetch(:verbose, true), :blue)
           elsif options[:force]
             log_status(:force, relative_path, options.fetch(:verbose, true), :yellow)
+            yield unless options[:noop]
           elsif options[:skip]
             log_status(:skip, relative_path, options.fetch(:verbose, true), :yellow)
           else

--- a/spec/unit/create_file_spec.rb
+++ b/spec/unit/create_file_spec.rb
@@ -46,12 +46,22 @@ RSpec.describe TTY::File, '#create_file' do
     end
 
     context 'and is not identical' do
-      it "logs forced status if force is true" do
-        file = tmp_path('README.md')
-        TTY::File.create_file(file, '# Title', verbose: false)
-        expect {
-          TTY::File.create_file(file, '# Header', verbose: true, force: true)
-        }.to output(/force/).to_stdout_from_any_process
+      context 'and :force is true' do
+        it "logs forced status to stdout" do
+          file = tmp_path('README.md')
+          TTY::File.create_file(file, '# Title', verbose: false)
+          expect {
+            TTY::File.create_file(file, '# Header', verbose: true, force: true)
+          }.to output(/force/).to_stdout_from_any_process
+        end
+        
+        it 'overrides the previous file' do
+          file = tmp_path('README.md')
+          TTY::File.create_file(file, '# Title', verbose: false)
+          TTY::File.create_file(file, '# Header', force: true)
+          content = File.read(file)
+          expect(content).to eq('# Header')
+        end
       end
 
       it "displays collision menu and overwrites" do


### PR DESCRIPTION
Hello, and thanks for this gem.

In using it I found a bug in the behaviour of TTY::File.create_file when the file existed and the `:force` option was specified.

The missing yield was making the :force action behave like :identical or :skip.

I will add tests ASAP.

