### PR TITLE
Improve most documented methods to accept Pathname instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 language: ruby
 sudo: false
 cache: bundler
+before_install:
+  - gem install bundler -v '< 2'
 script: "bundle update && bundle exec rake ci"
 rvm:
   - 2.0.0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,10 @@ module Helpers
     ::File.join(dir_path('tmp'), filename.to_s)
   end
 
+  def tmp_pathname(filename = nil)
+    Pathname.new(tmp_path(filename))
+  end
+
   def exists_and_identical?(source, dest)
     dest_path = tmp_path(dest)
     expect(::File.exist?(dest_path)).to be(true)

--- a/spec/unit/append_to_file_spec.rb
+++ b/spec/unit/append_to_file_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.describe TTY::File, '#append_to_file' do
+RSpec.shared_context "#append_to_file" do
   it "appends to file" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     TTY::File.append_to_file(file, "gem 'tty'", verbose: false)
     expect(File.read(file)).to eq([
       "gem 'nokogiri'\n",
@@ -13,7 +13,7 @@ RSpec.describe TTY::File, '#append_to_file' do
   end
 
   it "appends multiple lines to file" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     TTY::File.append_to_file(file, "gem 'tty'\n", "gem 'rake'", verbose: false)
     expect(File.read(file)).to eq([
       "gem 'nokogiri'\n",
@@ -25,7 +25,7 @@ RSpec.describe TTY::File, '#append_to_file' do
   end
 
   it "appends content in a block" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     TTY::File.append_to_file(file, verbose: false) { "gem 'tty'"}
     expect(File.read(file)).to eq([
       "gem 'nokogiri'\n",
@@ -36,7 +36,7 @@ RSpec.describe TTY::File, '#append_to_file' do
   end
 
   it "doesn't append if already present" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     TTY::File.append_to_file(file, "gem 'rack', '>=1.0'\n", force: false, verbose: false)
     expect(::File.read(file)).to eq([
       "gem 'nokogiri'\n",
@@ -46,7 +46,7 @@ RSpec.describe TTY::File, '#append_to_file' do
   end
 
   it "appends safely checking if content already present" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     TTY::File.safe_append_to_file(file, "gem 'rack', '>=1.0'\n", verbose: false)
 
     expect(::File.read(file)).to eq([
@@ -57,7 +57,7 @@ RSpec.describe TTY::File, '#append_to_file' do
   end
 
   it "appends multiple times by default" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     TTY::File.append_to_file(file, "gem 'tty'\n", verbose: false)
     TTY::File.append_to_file(file, "gem 'tty'\n", verbose: false)
     expect(::File.read(file)).to eq([
@@ -70,16 +70,32 @@ RSpec.describe TTY::File, '#append_to_file' do
   end
 
   it "logs action" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     expect {
       TTY::File.add_to_file(file, "gem 'tty'")
     }.to output(/\e\[32mappend\e\[0m.*Gemfile/).to_stdout_from_any_process
   end
 
   it "logs action without color" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     expect {
       TTY::File.add_to_file(file, "gem 'tty'", color: false)
     }.to output(/\s+append.*Gemfile/).to_stdout_from_any_process
+  end
+end
+
+module TTY::File
+  RSpec.describe "#append_to_file" do
+    context "when passed a String instance for the file argument" do
+      let(:path_factory) { method(:tmp_path) }
+
+      it_behaves_like "#append_to_file"
+    end
+
+    context "when passed a Pathname instance for the file argument" do
+      let(:path_factory) { method(:tmp_pathname) }
+
+      it_behaves_like "#append_to_file"
+    end
   end
 end

--- a/spec/unit/binary_spec.rb
+++ b/spec/unit/binary_spec.rb
@@ -24,14 +24,26 @@ RSpec.describe TTY::File, '#binary?' do
     end
   end
 
-  it "identifies image as binary" do
+  it "identifies image file as binary" do
     file = tmp_path('blackhole.png')
+
+    expect(TTY::File.binary?(file)).to eq(true)
+  end
+
+  it 'identifies image file provided by a Pathname instance as binary' do
+    file = tmp_pathname('blackhole.png')
 
     expect(TTY::File.binary?(file)).to eq(true)
   end
 
   it "indetifies text file as non-binary" do
     file = tmp_path('Gemfile')
+
+    expect(TTY::File.binary?(file)).to eq(false)
+  end
+
+  it 'identifies text file provided by a Pathname instance as non-binary' do
+    file = tmp_pathname('Gemfile')
 
     expect(TTY::File.binary?(file)).to eq(false)
   end

--- a/spec/unit/checksum_file_spec.rb
+++ b/spec/unit/checksum_file_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe TTY::File, '#checksum_file' do
     expect(checksum).to eq(expected)
   end
 
+  it "generates checksum for a Pathname instance" do
+    file = tmp_pathname('checksum/README.md')
+
+    checksum = TTY::File.checksum_file(file)
+    expected = '76ba1beb6c611fa32624ed253444138cdf23eb938a3812137f8a399c5b375bfe'
+
+    expect(checksum).to eq(expected)
+  end
+
   it "generates checksum for IO object" do
     io = StringIO.new("Some content\nThe end")
 

--- a/spec/unit/chmod_spec.rb
+++ b/spec/unit/chmod_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-RSpec.describe TTY::File, '#chmod' do
+RSpec.shared_context "#chmod" do
   context 'when octal permisssions' do
     it "adds permissions to file - user executable",
       unless: RSpec::Support::OS.windows? do
 
-      file = tmp_path('script.sh')
+      file = path_factory.call('script.sh')
       mode = File.lstat(file).mode
       expect(File.executable?(file)).to eq(false)
 
@@ -17,7 +17,7 @@ RSpec.describe TTY::File, '#chmod' do
     it "logs status when :verbose flag is true",
       unless: RSpec::Support::OS.windows? do
 
-      file = tmp_path('script.sh')
+      file = path_factory.call('script.sh')
       mode = File.lstat(file).mode
       expect(File.executable?(file)).to eq(false)
 
@@ -29,7 +29,7 @@ RSpec.describe TTY::File, '#chmod' do
     end
 
     it "doesn't change permission when :noop flag is true" do
-      file = tmp_path('script.sh')
+      file = path_factory.call('script.sh')
       mode = File.lstat(file).mode
       expect(File.executable?(file)).to eq(false)
 
@@ -43,7 +43,7 @@ RSpec.describe TTY::File, '#chmod' do
     it "adds permisions to file - user executable",
       unless: RSpec::Support::OS.windows? do
 
-      file = tmp_path('script.sh')
+      file = path_factory.call('script.sh')
       mode = File.lstat(file).mode
       expect(File.executable?(file)).to eq(false)
 
@@ -53,7 +53,7 @@ RSpec.describe TTY::File, '#chmod' do
     end
 
     it "removes permission for user executable" do
-      file = tmp_path('script.sh')
+      file = path_factory.call('script.sh')
       mode = File.lstat(file).mode
       expect(File.writable?(file)).to eq(true)
 
@@ -66,13 +66,29 @@ RSpec.describe TTY::File, '#chmod' do
     it "adds multiple permissions separated by comma",
       unless: RSpec::Support::OS.windows? do
 
-      file = tmp_path('script.sh')
+      file = path_factory.call('script.sh')
       mode = File.lstat(file).mode
       expect(File.executable?(file)).to eq(false)
 
       TTY::File.chmod(file, 'u+x,g+x', verbose: false)
 
       expect(File.lstat(file).mode).to eq(mode | TTY::File::U_X | TTY::File::G_X)
+    end
+  end
+end
+
+module TTY::File
+  RSpec.describe '#chmod' do
+    context "when passed a String instance for the file argument" do
+      let(:path_factory) { method(:tmp_path) }
+
+      it_behaves_like "#chmod"
+    end
+
+    context "when passed a Pathname instance for the file argument" do
+      let(:path_factory) { method(:tmp_pathname) }
+
+      it_behaves_like "#chmod"
     end
   end
 end

--- a/spec/unit/copy_directory_spec.rb
+++ b/spec/unit/copy_directory_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-RSpec.describe TTY::File, '#copy_directory' do
+RSpec.shared_context "#copy_directory" do
   it "copies directory of files recursively" do
-    app = tmp_path('cli_app')
-    apps = tmp_path('apps')
+    app  = path_factory.call('cli_app')
+    apps = path_factory.call('apps')
 
     variables = OpenStruct.new
     variables[:name] = 'tty'
@@ -29,8 +29,8 @@ RSpec.describe TTY::File, '#copy_directory' do
   end
 
   it "copies top level directory of files and evalutes templates" do
-    app  = tmp_path('cli_app')
-    apps = tmp_path('apps')
+    app  = path_factory.call('cli_app')
+    apps = path_factory.call('apps')
 
     variables = OpenStruct.new
     variables[:name] = 'tty'
@@ -50,8 +50,8 @@ RSpec.describe TTY::File, '#copy_directory' do
   end
 
   it "handles glob characters in the path" do
-    src = tmp_path("foo[1]")
-    dest = tmp_path("foo1")
+    src  = path_factory.call("foo[1]")
+    dest = path_factory.call("foo1")
     TTY::File.copy_directory(src, dest, verbose: false)
 
     expect(Find.find(dest).to_a).to eq([
@@ -61,8 +61,8 @@ RSpec.describe TTY::File, '#copy_directory' do
   end
 
   it "ignores excluded directories" do
-    src = tmp_path('cli_app')
-    dest = tmp_path('ignored')
+    src  = path_factory.call('cli_app')
+    dest = path_factory.call('ignored')
 
     variables = OpenStruct.new
     variables[:name] = 'tty'
@@ -90,8 +90,8 @@ RSpec.describe TTY::File, '#copy_directory' do
   end
 
   it "logs status" do
-    app  = tmp_path('cli_app')
-    apps = tmp_path('apps')
+    app  = path_factory.call('cli_app')
+    apps = path_factory.call('apps')
 
     variables = OpenStruct.new
     variables[:name] = 'tty'
@@ -102,5 +102,21 @@ RSpec.describe TTY::File, '#copy_directory' do
     }.to output(
       %r{create(.*)apps/tty_cli.rb\n(.*)create(.*)apps/README\n(.*)create(.*)apps/command.rb\n}m
     ).to_stdout_from_any_process
+  end
+end
+
+module TTY::File
+  RSpec.describe "#copy_directory" do
+    context "when passed String instances for the file arguments" do
+      let(:path_factory) { method(:tmp_path) }
+
+      it_behaves_like "#copy_directory"
+    end
+
+    context "when passed Pathname instances for the file arguments" do
+      let(:path_factory) { method(:tmp_pathname) }
+
+      it_behaves_like "#copy_directory"
+    end
   end
 end

--- a/spec/unit/copy_directory_spec.rb
+++ b/spec/unit/copy_directory_spec.rb
@@ -12,7 +12,7 @@ RSpec.shared_context "#copy_directory" do
 
     TTY::File.copy_directory(app, apps, context: variables, verbose: false)
 
-    expect(Find.find(apps).to_a).to eq([
+    expect(Find.find(apps.to_s).to_a).to eq([
       tmp_path('apps'),
       tmp_path('apps/README'),
       tmp_path('apps/command.rb'),
@@ -41,7 +41,7 @@ RSpec.shared_context "#copy_directory" do
                                         context: variables,
                                         verbose: false)
 
-    expect(Find.find(apps).to_a).to eq([
+    expect(Find.find(apps.to_s).to_a).to eq([
       tmp_path('apps'),
       tmp_path('apps/README'),
       tmp_path('apps/command.rb'),
@@ -54,7 +54,7 @@ RSpec.shared_context "#copy_directory" do
     dest = path_factory.call("foo1")
     TTY::File.copy_directory(src, dest, verbose: false)
 
-    expect(Find.find(dest).to_a).to eq([
+    expect(Find.find(dest.to_s).to_a).to eq([
       tmp_path('foo1'),
       tmp_path('foo1/README.md')
     ])
@@ -73,7 +73,7 @@ RSpec.shared_context "#copy_directory" do
                                         exclude: %r{excluded/},
                                         verbose: false)
 
-    expect(Find.find(dest).to_a).to eq([
+    expect(Find.find(dest.to_s).to_a).to eq([
       tmp_path('ignored'),
       tmp_path('ignored/README'),
       tmp_path('ignored/command.rb'),

--- a/spec/unit/create_directory_spec.rb
+++ b/spec/unit/create_directory_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe TTY::File, '#create_directory' do
     app_dir = tmp_path('app')
 
     tree = {
-      tmp_path('app') => [
+      app_dir => [
         'empty_file',
         ['full_file', 'File with contents'],
         'subdir' => [

--- a/spec/unit/create_directory_spec.rb
+++ b/spec/unit/create_directory_spec.rb
@@ -42,7 +42,7 @@ RSpec.shared_context "#create_directory" do
 
     TTY::File.create_directory(tree, verbose: false)
 
-    expect(Find.find(app_dir).to_a).to eq([
+    expect(Find.find(app_dir.to_s).to_a).to eq([
       tmp_path('app'),
       tmp_path('app/empty'),
       tmp_path('app/empty_file'),
@@ -67,7 +67,7 @@ RSpec.shared_context "#create_directory" do
 
     TTY::File.create_dir(tree, app_dir, verbose: false)
 
-    expect(Find.find(app_dir).to_a).to eq([
+    expect(Find.find(app_dir.to_s).to_a).to eq([
       tmp_path('parent'),
       tmp_path('parent/app'),
       tmp_path('parent/app/file'),

--- a/spec/unit/create_directory_spec.rb
+++ b/spec/unit/create_directory_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.describe TTY::File, '#create_directory' do
+RSpec.shared_context "#create_directory" do
   it "creates empty directory" do
-    app_dir = tmp_path('app')
+    app_dir = path_factory.call('app')
 
     TTY::File.create_directory(app_dir, verbose: false)
 
@@ -10,7 +10,7 @@ RSpec.describe TTY::File, '#create_directory' do
   end
 
   it "logs status" do
-    doc_dir = tmp_path('doc')
+    doc_dir = path_factory.call('doc')
 
     expect {
       TTY::File.create_dir(doc_dir, verbose: true)
@@ -18,7 +18,7 @@ RSpec.describe TTY::File, '#create_directory' do
   end
 
   it "logs status wihtout color" do
-    doc_dir = tmp_path('doc')
+    doc_dir = path_factory.call('doc')
 
     expect {
       TTY::File.create_dir(doc_dir, verbose: true, color: false)
@@ -26,7 +26,7 @@ RSpec.describe TTY::File, '#create_directory' do
   end
 
   it "creates tree of dirs and files" do
-    app_dir = tmp_path('app')
+    app_dir = path_factory.call('app')
 
     tree = {
       app_dir => [
@@ -56,7 +56,7 @@ RSpec.describe TTY::File, '#create_directory' do
   end
 
   it "creates tree of dirs in parent directory" do
-    app_dir = tmp_path('parent')
+    app_dir = path_factory.call('parent')
 
     tree = {
       'app' => [
@@ -75,5 +75,21 @@ RSpec.describe TTY::File, '#create_directory' do
       tmp_path('parent/app/subdir/file1'),
       tmp_path('parent/app/subdir/file2')
     ])
+  end
+end
+
+module TTY::File
+  RSpec.describe "#create_directory" do
+    context "when passed a String instance for the directory argument" do
+      let(:path_factory) { method(:tmp_path) }
+
+      it_behaves_like "#create_directory"
+    end
+
+    context "when passed a Pathname instance for the directory argument" do
+      let(:path_factory) { method(:tmp_pathname) }
+
+      it_behaves_like "#create_directory"
+    end
   end
 end

--- a/spec/unit/create_file_spec.rb
+++ b/spec/unit/create_file_spec.rb
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 
-RSpec.describe TTY::File, '#create_file' do
+RSpec.shared_context '#create_file' do
   context 'when new file' do
     it "creates file" do
       expect {
-        TTY::File.create_file(tmp_path('doc/README.md'))
+        TTY::File.create_file(path_factory.call('doc/README.md'))
       }.to output(/create/).to_stdout_from_any_process
 
       expect(File.exist?(tmp_path('doc/README.md'))).to eq(true)
     end
 
     it "creates file with content" do
-      file = tmp_path('doc/README.md')
+      file = path_factory.call('doc/README.md')
       TTY::File.create_file(file, '# Title', verbose: false)
 
       expect(File.read(file)).to eq('# Title')
     end
 
     it "creates file with content in a block" do
-      file = tmp_path('doc/README.md')
+      file = path_factory.call('doc/README.md')
       TTY::File.create_file(file, verbose: false) do
         "# Title"
       end
@@ -27,7 +27,7 @@ RSpec.describe TTY::File, '#create_file' do
     end
 
     it "doesn't create file if :noop is true" do
-      file = tmp_path('doc/README.md')
+      file = path_factory.call('doc/README.md')
       TTY::File.create_file(file, '# Title', noop: true, verbose: false)
 
       expect(File.exist?(file)).to eq(false)
@@ -37,7 +37,7 @@ RSpec.describe TTY::File, '#create_file' do
   context 'when file exists' do
     context 'and is identical' do
       it "logs identical status" do
-        file = tmp_path('README.md')
+        file = path_factory.call('README.md')
         TTY::File.create_file(file, '# Title', verbose: false)
         expect {
           TTY::File.create_file(file, '# Title', verbose: true)
@@ -48,7 +48,7 @@ RSpec.describe TTY::File, '#create_file' do
     context 'and is not identical' do
       context 'and :force is true' do
         it "logs forced status to stdout" do
-          file = tmp_path('README.md')
+          file = path_factory.call('README.md')
           TTY::File.create_file(file, '# Title', verbose: false)
           expect {
             TTY::File.create_file(file, '# Header', verbose: true, force: true)
@@ -56,7 +56,7 @@ RSpec.describe TTY::File, '#create_file' do
         end
 
         it 'overrides the previous file' do
-          file = tmp_path('README.md')
+          file = path_factory.call('README.md')
           TTY::File.create_file(file, '# Title', verbose: false)
           TTY::File.create_file(file, '# Header', force: true, verbose: false)
           content = File.read(file)
@@ -70,7 +70,7 @@ RSpec.describe TTY::File, '#create_file' do
         test_prompt.input.rewind
         allow(TTY::Prompt).to receive(:new).and_return(test_prompt)
 
-        file = tmp_path('README.md')
+        file = path_factory.call('README.md')
         TTY::File.create_file(file, '# Title', verbose: false)
 
         expect {
@@ -86,7 +86,7 @@ RSpec.describe TTY::File, '#create_file' do
         test_prompt.input.rewind
         allow(TTY::Prompt).to receive(:new).and_return(test_prompt)
 
-        file = tmp_path('README.md')
+        file = path_factory.call('README.md')
         TTY::File.create_file(file, '# Title', verbose: false)
 
         expect {
@@ -102,7 +102,7 @@ RSpec.describe TTY::File, '#create_file' do
         test_prompt.input.rewind
         allow(TTY::Prompt).to receive(:new).and_return(test_prompt)
 
-        file = tmp_path('README.md')
+        file = path_factory.call('README.md')
         TTY::File.create_file(file, '# Title', verbose: false)
 
         expect {
@@ -111,6 +111,22 @@ RSpec.describe TTY::File, '#create_file' do
 
         expect(File.read(file)).to eq('# Title')
       end
+    end
+  end
+end
+
+module TTY::File
+  RSpec.describe "#create_file" do
+    context 'when passed a String instance as the file argument' do
+      let(:path_factory) { method(:tmp_path) }
+
+      it_behaves_like "#create_file"
+    end
+
+    context 'when passed a Pathname instance as the file argument' do
+      let(:path_factory) { method(:tmp_pathname) }
+
+      it_behaves_like "#create_file"
     end
   end
 end

--- a/spec/unit/diff_spec.rb
+++ b/spec/unit/diff_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-RSpec.describe TTY::File, '#diff' do
+RSpec.shared_context '#diff' do
   it "diffs two files" do
-    file_a = tmp_path('diff/file_a')
-    file_b = tmp_path('diff/file_b')
+    file_a = path_factory.call('diff/file_a')
+    file_b = path_factory.call('diff/file_b')
 
     diff = TTY::File.diff(file_a, file_b, verbose: false)
 
@@ -18,13 +18,13 @@ RSpec.describe TTY::File, '#diff' do
   end
 
   it "diffs identical files" do
-    src_a = tmp_path('diff/file_a')
+    src_a = path_factory.call('diff/file_a')
 
     expect(TTY::File.diff(src_a, src_a, verbose: false)).to eq('')
   end
 
   it "diffs a file and a string" do
-    src_a = tmp_path('diff/file_a')
+    src_a = path_factory.call('diff/file_a')
     src_b = "aaa\nxxx\nccc\n"
 
     diff = TTY::File.diff(src_a, src_b, verbose: false)
@@ -56,8 +56,8 @@ RSpec.describe TTY::File, '#diff' do
   end
 
   it "logs status" do
-    file_a = tmp_path('diff/file_a')
-    file_b = tmp_path('diff/file_b')
+    file_a = path_factory.call('diff/file_a')
+    file_b = path_factory.call('diff/file_b')
 
     expect {
       TTY::File.diff_files(file_a, file_b, verbose: true)
@@ -65,8 +65,8 @@ RSpec.describe TTY::File, '#diff' do
   end
 
   it "doesn't diff files when :noop option is given" do
-    file_a = tmp_path('diff/file_a')
-    file_b = tmp_path('diff/file_b')
+    file_a = path_factory.call('diff/file_a')
+    file_b = path_factory.call('diff/file_b')
 
     diff = TTY::File.diff(file_a, file_b, verbose: false, noop: true)
 
@@ -74,8 +74,8 @@ RSpec.describe TTY::File, '#diff' do
   end
 
   it "doesn't diff if first file is too large" do
-    file_a = tmp_path('diff/file_a')
-    file_b = tmp_path('diff/file_b')
+    file_a = path_factory.call('diff/file_a')
+    file_b = path_factory.call('diff/file_b')
 
     expect {
       TTY::File.diff(file_a, file_b, threshold: 10)
@@ -83,11 +83,27 @@ RSpec.describe TTY::File, '#diff' do
   end
 
   it "doesn't diff binary files" do
-    file_a = tmp_path('blackhole.png')
-    file_b = tmp_path('diff/file_b')
+    file_a = path_factory.call('blackhole.png')
+    file_b = path_factory.call('diff/file_b')
 
     expect {
       TTY::File.diff(file_a, file_b)
     }.to raise_error(ArgumentError, /is binary, diff output suppressed/)
+  end
+end
+
+module TTY::File
+  RSpec.describe "#diff" do
+    context "when passed String instances for the file arguments" do
+      let(:path_factory) { method(:tmp_path) }
+
+      it_behaves_like "#diff"
+    end
+
+    context "when passed Pathname instances for the file arguments" do
+      let(:path_factory) { method(:tmp_pathname) }
+
+      it_behaves_like "#diff"
+    end
   end
 end

--- a/spec/unit/inject_into_file_spec.rb
+++ b/spec/unit/inject_into_file_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.describe TTY::File, '#inject_into_file' do
+RSpec.shared_context '#inject_into_file' do
   it "injects content into file :before" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     TTY::File.inject_into_file(file, "gem 'tty'\n",
       before: "gem 'rack', '>=1.0'\n", verbose: false)
 
@@ -15,7 +15,7 @@ RSpec.describe TTY::File, '#inject_into_file' do
   end
 
   it "injects content into file :after" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
 
     expect {
       TTY::File.inject_into_file(file, "gem 'tty'", after: "gem 'rack', '>=1.0'\n")
@@ -30,7 +30,7 @@ RSpec.describe TTY::File, '#inject_into_file' do
   end
 
   it "accepts content in block" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
 
     expect {
       TTY::File.insert_into_file(file, after: "gem 'rack', '>=1.0'\n") do
@@ -47,7 +47,7 @@ RSpec.describe TTY::File, '#inject_into_file' do
   end
 
   it "accepts many lines" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
 
     TTY::File.inject_into_file(file, "gem 'tty'\n", "gem 'loaf'",
       after: "gem 'rack', '>=1.0'\n", verbose: false)
@@ -62,7 +62,7 @@ RSpec.describe TTY::File, '#inject_into_file' do
   end
 
   it "logs action" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
 
     expect {
     TTY::File.inject_into_file(file, "gem 'tty'\n", "gem 'loaf'",
@@ -71,7 +71,7 @@ RSpec.describe TTY::File, '#inject_into_file' do
   end
 
   it "logs action without color" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
 
     expect {
     TTY::File.inject_into_file(file, "gem 'tty'\n", "gem 'loaf'",
@@ -80,7 +80,7 @@ RSpec.describe TTY::File, '#inject_into_file' do
   end
 
   it "doesn't inject new content if already present" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     TTY::File.inject_into_file(file, "gem 'tty'",
                                after: "gem 'rack', '>=1.0'\n", verbose: false)
 
@@ -104,7 +104,7 @@ RSpec.describe TTY::File, '#inject_into_file' do
   end
 
   it "checks if a content can be safely injected" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     TTY::File.safe_inject_into_file(file, "gem 'tty'",
                                     after: "gem 'rack', '>=1.0'\n", verbose: false)
     expect(::File.read(file)).to eq([
@@ -116,7 +116,7 @@ RSpec.describe TTY::File, '#inject_into_file' do
   end
 
   it "changes content already present if :force flag is true" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
 
     TTY::File.inject_into_file(file, "gem 'tty'\n",
       before: "gem 'nokogiri'", verbose: false)
@@ -141,7 +141,7 @@ RSpec.describe TTY::File, '#inject_into_file' do
   end
 
   it "fails to inject into non existent file" do
-    file = tmp_path('unknown')
+    file = path_factory.call('unknown')
 
     expect {
       TTY::File.inject_into_file(file, "gem 'tty'", after: "gem 'rack', '>=1.0'\n")
@@ -149,7 +149,7 @@ RSpec.describe TTY::File, '#inject_into_file' do
   end
 
   it "doesn't change content when :noop flag is true" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     TTY::File.inject_into_file(file, "gem 'tty'\n",
       before: "gem 'nokogiri'", verbose: false, noop: true)
 
@@ -158,5 +158,21 @@ RSpec.describe TTY::File, '#inject_into_file' do
       "gem 'rails', '5.0.0'\n",
       "gem 'rack', '>=1.0'\n",
     ].join)
+  end
+end
+
+module TTY::File
+  RSpec.describe "#inject_into_file" do
+    context "when passed a String instance for the file argument" do
+      let(:path_factory) { method(:tmp_path) }
+
+      it_behaves_like "#inject_into_file"
+    end
+
+    context "when passed a Pathname instance for the file argument" do
+      let(:path_factory) { method(:tmp_pathname) }
+
+      it_behaves_like "#inject_into_file"
+    end
   end
 end

--- a/spec/unit/prepend_to_file_spec.rb
+++ b/spec/unit/prepend_to_file_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.describe TTY::File, '#prepend_to_file' do
+RSpec.shared_context '#prepend_to_file' do
   it "appends to file" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     result = TTY::File.prepend_to_file(file, "gem 'tty'\n", verbose: false)
     expect(result).to eq(true)
     expect(File.read(file)).to eq([
@@ -14,7 +14,7 @@ RSpec.describe TTY::File, '#prepend_to_file' do
   end
 
   it "prepends multiple lines to file" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     TTY::File.prepend_to_file(file, "gem 'tty'\n", "gem 'rake'\n", verbose: false)
     expect(File.read(file)).to eq([
       "gem 'tty'\n",
@@ -26,7 +26,7 @@ RSpec.describe TTY::File, '#prepend_to_file' do
   end
 
   it "prepends content in a block" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     TTY::File.prepend_to_file(file, verbose: false) { "gem 'tty'\n"}
     expect(File.read(file)).to eq([
       "gem 'tty'\n",
@@ -37,7 +37,7 @@ RSpec.describe TTY::File, '#prepend_to_file' do
   end
 
   it "doesn't prepend if already present" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     TTY::File.prepend_to_file(file, "gem 'nokogiri'\n", force: false, verbose: false)
     expect(::File.read(file)).to eq([
       "gem 'nokogiri'\n",
@@ -47,7 +47,7 @@ RSpec.describe TTY::File, '#prepend_to_file' do
   end
 
   it "checks if a content can be safely prepended" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     TTY::File.safe_prepend_to_file(file, "gem 'nokogiri'\n", verbose: false)
     expect(::File.read(file)).to eq([
       "gem 'nokogiri'\n",
@@ -57,7 +57,7 @@ RSpec.describe TTY::File, '#prepend_to_file' do
   end
 
   it "doesn't prepend if already present for multiline content" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     TTY::File.prepend_to_file(file, "gem 'nokogiri'\n", verbose: false)
     TTY::File.prepend_to_file(file, "gem 'nokogiri'\n", "gem 'nokogiri'\n", force: false, verbose: false)
     expect(::File.read(file)).to eq([
@@ -69,7 +69,7 @@ RSpec.describe TTY::File, '#prepend_to_file' do
   end
 
   it "prepends multiple times if forced" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     TTY::File.prepend_to_file(file, "gem 'nokogiri'\n", force: true, verbose: false)
     TTY::File.prepend_to_file(file, "gem 'nokogiri'\n", "gem 'nokogiri'\n", force: true, verbose: false)
     expect(::File.read(file)).to eq([
@@ -83,16 +83,32 @@ RSpec.describe TTY::File, '#prepend_to_file' do
   end
 
   it "logs action" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     expect {
       TTY::File.prepend_to_file(file, "gem 'tty'")
     }.to output(/\e\[32mprepend\e\[0m.*Gemfile/).to_stdout_from_any_process
   end
 
   it "logs action without color" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     expect {
       TTY::File.prepend_to_file(file, "gem 'tty'", color: false)
     }.to output(/\s+prepend.*Gemfile/).to_stdout_from_any_process
+  end
+end
+
+module TTY::File
+  RSpec.describe "#prepend_to_file" do
+    context "when passed a String instance for the file argument" do
+      let(:path_factory) { method(:tmp_path) }
+
+      it_behaves_like "#prepend_to_file"
+    end
+
+    context "when passed a Pathname instance for the file argument" do
+      let(:path_factory) { method(:tmp_pathname) }
+
+      it_behaves_like "#prepend_to_file"
+    end
   end
 end

--- a/spec/unit/remove_file_spec.rb
+++ b/spec/unit/remove_file_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.describe TTY::File, '#remove_file' do
+RSpec.shared_context '#remove_file' do
   it "removes a given file", unless: RSpec::Support::OS.windows? do
-    src_path = tmp_path('Gemfile')
+    src_path = path_factory.call('Gemfile')
 
     TTY::File.remove_file(src_path, verbose: false)
 
@@ -10,7 +10,7 @@ RSpec.describe TTY::File, '#remove_file' do
   end
 
   it "removes a directory" do
-    src_path = tmp_path('templates')
+    src_path = path_factory.call('templates')
 
     TTY::File.remove_file(src_path, verbose: false)
 
@@ -18,7 +18,7 @@ RSpec.describe TTY::File, '#remove_file' do
   end
 
   it "pretends removing file" do
-    src_path = tmp_path('Gemfile')
+    src_path = path_factory.call('Gemfile')
 
     TTY::File.remove_file(src_path, noop: true, verbose: false)
 
@@ -26,7 +26,7 @@ RSpec.describe TTY::File, '#remove_file' do
   end
 
   it "removes files in secure mode" do
-    src_path = tmp_path('Gemfile')
+    src_path = path_factory.call('Gemfile')
     allow(::FileUtils).to receive(:rm_r)
 
     TTY::File.remove_file(src_path, verbose: false, secure: false)
@@ -36,7 +36,7 @@ RSpec.describe TTY::File, '#remove_file' do
   end
 
   it "logs status" do
-    src_path = tmp_path('Gemfile')
+    src_path = path_factory.call('Gemfile')
 
     expect {
       TTY::File.remove_file(src_path, noop: true)
@@ -44,10 +44,26 @@ RSpec.describe TTY::File, '#remove_file' do
   end
 
   it "logs status without color" do
-    src_path = tmp_path('Gemfile')
+    src_path = path_factory.call('Gemfile')
 
     expect {
       TTY::File.remove_file(src_path, noop: true, color: false)
     }.to output(/\s+remove(.*)Gemfile/).to_stdout_from_any_process
+  end
+end
+
+module TTY::File
+  RSpec.describe "#remove_file" do
+    context "when passed a String instance for the file argument" do
+      let(:path_factory) { method(:tmp_path) }
+
+      it_behaves_like "#remove_file"
+    end
+
+    context "when passed a Pathname instance for the file argument" do
+      let(:path_factory) { method(:tmp_pathname) }
+
+      it_behaves_like "#remove_file"
+    end
   end
 end

--- a/spec/unit/replace_in_file_spec.rb
+++ b/spec/unit/replace_in_file_spec.rb
@@ -1,8 +1,9 @@
+# -*- coding: utf-8 -*-
 # frozen_string_literal: true
 
-RSpec.describe TTY::File, '#replace_in_file' do
+RSpec.shared_context '#replace_in_file' do
   it "replaces file content with a matching string" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     status = nil
     expect {
       status = TTY::File.replace_in_file(file, /gem 'rails'/, "gem 'hanami'")
@@ -17,7 +18,7 @@ RSpec.describe TTY::File, '#replace_in_file' do
   end
 
   it "replaces file content with a matching block value" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     status = nil
     expect {
       status =TTY::File.replace_in_file(file, /gem 'rails'/, verbose: false) do |match|
@@ -34,7 +35,7 @@ RSpec.describe TTY::File, '#replace_in_file' do
   end
 
   it "doesn't match file content" do
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     content = ::File.read(file)
     status = TTY::File.replace_in_file(file, /unknown/, 'Hello', verbose: false)
 
@@ -44,7 +45,7 @@ RSpec.describe TTY::File, '#replace_in_file' do
 
   it "silences verbose output" do
     content = "gem 'hanami'"
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
     expect {
       TTY::File.replace_in_file(file, /gem 'rails'/, content, verbose: false)
     }.to_not output(/replace/).to_stdout_from_any_process
@@ -52,14 +53,14 @@ RSpec.describe TTY::File, '#replace_in_file' do
 
   it "fails to replace content when missing correct file path" do
     expect {
-      TTY::File.replace_in_file('/non-existent-path',
+      TTY::File.replace_in_file(path_factory.call('non-existent-path'),
         /gem 'rails'/, "gem 'hanami'", verbose: false)
     }.to raise_error(ArgumentError, /File path (.)* does not exist/)
   end
 
   it "logs action" do
     content = "gem 'hanami'"
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
 
     expect {
       TTY::File.replace_in_file(file, /gem 'rails'/, content, noop: true)
@@ -68,7 +69,7 @@ RSpec.describe TTY::File, '#replace_in_file' do
 
   it "logs action without color" do
     content = "gem 'hanami'"
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
 
     expect {
       TTY::File.replace_in_file(file, /gem 'rails'/, content,
@@ -78,7 +79,7 @@ RSpec.describe TTY::File, '#replace_in_file' do
 
   it "allows for noop run" do
     content = "gem 'hanami'"
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
 
     TTY::File.replace_in_file(file, /gem 'rails'/, content,
                               noop: true, verbose: false)
@@ -92,7 +93,7 @@ RSpec.describe TTY::File, '#replace_in_file' do
 
   it "doesn't replace content when no match found" do
     content = "gem 'hanami'"
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
 
     status = TTY::File.gsub_file(file, /gem 'rails'/, content, verbose: false)
     expect(status).to eq(true)
@@ -114,7 +115,7 @@ RSpec.describe TTY::File, '#replace_in_file' do
 
   it "replaces with multibyte content" do
     content = "gem 'ようこそ'"
-    file = tmp_path('Gemfile')
+    file = path_factory.call('Gemfile')
 
     TTY::File.gsub_file(file, /gem 'rails'/, content, verbose: false)
     expect(File.open(file, 'r:UTF-8', &:read)).to eq([
@@ -122,5 +123,21 @@ RSpec.describe TTY::File, '#replace_in_file' do
       "#{content}, '5.0.0'\n",
       "gem 'rack', '>=1.0'\n"
     ].join)
+  end
+end
+
+module TTY::File
+  RSpec.describe "#replace_in_file" do
+    context "when passed a String instance for the file argument" do
+      let(:path_factory) { method(:tmp_path) }
+
+      it_behaves_like "#replace_in_file"
+    end
+
+    context "when passed a Pathname instance for the file argument" do
+      let(:path_factory) { method(:tmp_pathname) }
+
+      it_behaves_like "#replace_in_file"
+    end
   end
 end

--- a/spec/unit/tail_file_spec.rb
+++ b/spec/unit/tail_file_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.describe TTY::File, '#tail_file' do
+RSpec.shared_context '#tail_file' do
   it "tails file for lines with chunks smaller than file size" do
-    file = tmp_path('tail/lines')
+    file = path_factory.call('tail/lines')
 
     lines = TTY::File.tail_file(file, 5, chunk_size: 2**3)
 
@@ -16,7 +16,7 @@ RSpec.describe TTY::File, '#tail_file' do
   end
 
   it "tails file for lines with chunks equal file size" do
-    file = tmp_path('tail/lines')
+    file = path_factory.call('tail/lines')
 
     lines = TTY::File.tail_file(file, 5, chunk_size: file.size)
 
@@ -31,7 +31,7 @@ RSpec.describe TTY::File, '#tail_file' do
   end
 
   it "tails file for lines with chunks larger than file size" do
-    file = tmp_path('tail/lines')
+    file = path_factory.call('tail/lines')
 
     lines = TTY::File.tail_file(file, 5, chunk_size: 2**9)
 
@@ -45,7 +45,7 @@ RSpec.describe TTY::File, '#tail_file' do
   end
 
   it "tails file and yields lines" do
-    file = tmp_path('tail/lines')
+    file = path_factory.call('tail/lines')
     lines = []
 
     TTY::File.tail_file(file, 5, chunk_size: 8) do |line|
@@ -59,5 +59,21 @@ RSpec.describe TTY::File, '#tail_file' do
       "line15",
       "line16"
     ])
+  end
+end
+
+module TTY::File
+  RSpec.describe "#tail_file" do
+    context "when passed a String instance for the file argument" do
+      let(:path_factory) { method(:tmp_path) }
+
+      it_behaves_like "#tail_file"
+    end
+
+    context "when passed a Pathname instance for the file argument" do
+      let(:path_factory) { method(:tmp_pathname) }
+
+      it_behaves_like "#tail_file"
+    end
   end
 end


### PR DESCRIPTION
### Describe the change
Improve every documented method except `::copy_metadata` and `::escape_glob_path` (explanations for each in the 2nd commit) to accept Pathname instances for their file arguments.
This addresses #7 

### Why are we doing this?
During use, I assumed they already did.

### Benefits
I assume other people may assume the methods will accept Pathname instances as well. They won't be  unpleasantly surprised.

### Drawbacks
It makes some of the testing slightly weird, because of the reliance on shared contexts. I think other maintainers will be able to understand what's going on pretty easily, and if they don't and just cargo cult, then they're most likely to do so in the shared contexts (since that's where the tests are), which will work out fine.

### Other Notes
I was thinking about calling out the test structure in the Contributing section of the Readme, but that honestly felt a little presumptuous on my part. Let me know if you do want me to add an explanation of the new complexity in the test suite there.

### Requirements
Put an X between brackets on each line if you have done the item:
[X] Tests written & passing locally?
[] Code style checked?
[] Rebased with `master` branch?
[X] Documentation updated?
